### PR TITLE
Initialize parent module with Java 17 and Spring Boot 3.4.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*/.idea/*
+.idea/sonarlint/*
+.idea/*
+**/target/**

--- a/shopping-parent/.gitignore
+++ b/shopping-parent/.gitignore
@@ -1,0 +1,34 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+/.project
+.settings/
+
+*/.idea/*
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+*.json
+

--- a/shopping-parent/README.md
+++ b/shopping-parent/README.md
@@ -1,0 +1,40 @@
+# shopping-parent
+
+This is the **parent project** for the Shopping Cart System built with **Java 17** and **Spring Boot 3.4.3**.
+
+It provides centralized configuration for dependency and plugin management across all microservices in the system.
+
+## ✅ Purpose
+
+- Define consistent dependency versions
+- Share build configuration across all modules
+- Simplify maintenance and promote clean project structure
+
+## 📦 Modules managed by this parent:
+
+- `common-entities`: Shared DTOs and entity definitions
+- `shopping-auth`: Authentication and JWT handling
+- `product-service`: Proxy for external product API
+- `order-service`: Order management logic
+- `payment-service`: Simulated payment processing
+
+## 🛠 Tech Stack
+
+- Java 17 (LTS)
+- Spring Boot 3.4.3
+- Maven 3.8+
+- UTF-8 encoding
+
+## 🔧 Features
+
+- Inherits Spring Boot BOM for dependency consistency
+- Compiler plugin configured for Java 17
+- Spring Boot Maven plugin enabled
+- Ready to be imported into any IDE (IntelliJ, VS Code)
+
+## 📁 Usage
+
+When cloning the full project:
+
+```bash
+mvn clean install

--- a/shopping-parent/pom.xml
+++ b/shopping-parent/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.shopping</groupId>
+	<artifactId>shopping-parent</artifactId>
+	<version>1.0.0</version>
+	<packaging>pom</packaging>
+	<name>shopping-parent</name>
+	<description>Parent POM for Shopping Cart Microservices Project (Spring Boot 3.4 / Java 17)</description>
+
+	<properties>
+		<java.version>17</java.version>
+		<spring.boot.version>3.4.3</spring.boot.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<version>${spring.boot.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.10.1</version>
+					<configuration>
+						<source>${java.version}</source>
+						<target>${java.version}</target>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-maven-plugin</artifactId>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+
+	<modules>
+		<module>../common-entities</module>
+		<module>../shopping-auth</module>
+		<module>../product-service</module>
+		<module>../order-service</module>
+		<module>../payment-service</module>
+	</modules>
+
+</project>


### PR DESCRIPTION
This pull request adds the shopping-parent module which defines the base configuration for all microservices in the shopping-cart backend system. It includes dependency management, Java 17 compiler settings, and Spring Boot 3.4.3 BOM integration.
