### PR TITLE
Add order-service with full JWT-secured endpoints and JPA persistence

### DIFF
--- a/common-entities/src/main/java/com/shopping/common/dto/OrderItemDto.java
+++ b/common-entities/src/main/java/com/shopping/common/dto/OrderItemDto.java
@@ -1,0 +1,13 @@
+package com.shopping.common.dto;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderItemDto {
+    private Long productId;
+    private Integer quantity;
+    private Double price;
+}

--- a/common-entities/src/main/java/com/shopping/common/dto/OrderRequestDto.java
+++ b/common-entities/src/main/java/com/shopping/common/dto/OrderRequestDto.java
@@ -1,0 +1,13 @@
+package com.shopping.common.dto;
+
+import lombok.*;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderRequestDto {
+    private Long userId;
+    private List<OrderItemDto> items;
+}

--- a/common-entities/src/main/java/com/shopping/common/dto/OrderResponseDto.java
+++ b/common-entities/src/main/java/com/shopping/common/dto/OrderResponseDto.java
@@ -1,0 +1,17 @@
+package com.shopping.common.dto;
+
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderResponseDto {
+    private Long id;
+    private Long userId;
+    private LocalDateTime orderDate;
+    private Double total;
+    private List<OrderItemDto> items;
+}

--- a/common-entities/src/main/java/com/shopping/common/entity/order/Order.java
+++ b/common-entities/src/main/java/com/shopping/common/entity/order/Order.java
@@ -1,0 +1,28 @@
+package com.shopping.common.entity.order;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "orders")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private LocalDateTime orderDate;
+
+    private Double total;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderDetail> orderDetails;
+}

--- a/common-entities/src/main/java/com/shopping/common/entity/order/OrderDetail.java
+++ b/common-entities/src/main/java/com/shopping/common/entity/order/OrderDetail.java
@@ -1,0 +1,27 @@
+package com.shopping.common.entity.order;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "order_details")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderDetail {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long productId;
+
+    private Integer quantity;
+
+    private Double price;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+}

--- a/order-service/.gitignore
+++ b/order-service/.gitignore
@@ -1,0 +1,34 @@
+HELP.md
+target/
+!**/src/main/**/target/
+!**/src/test/**/target/
+.mvn
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+bin/

--- a/order-service/README.md
+++ b/order-service/README.md
@@ -1,0 +1,98 @@
+# 📦 Order Service
+
+This microservice manages **shopping orders**, including order creation, retrieval by ID, and listing all orders. It stores orders and their associated order items in a PostgreSQL database.
+
+---
+
+## 🔐 JWT Authentication
+
+All endpoints (except `/actuator/health`) are **protected** with JWT.
+
+- Add your token in Postman under **Authorization → Bearer Token**, or  
+- Include it in the headers as:  
+  `Authorization: Bearer <your_token>`
+
+---
+
+## 🚀 Endpoints
+
+| Method | Endpoint             | Description               |
+|--------|----------------------|---------------------------|
+| POST   | `/v1/orders`         | Create a new order        |
+| GET    | `/v1/orders/{id}`    | Get order by ID           |
+| GET    | `/v1/orders`         | Get all orders            |
+
+---
+
+## 🧾 Sample Request - Create Order
+
+```json
+POST /v1/orders
+Authorization: Bearer <your_token>
+Content-Type: application/json
+
+{
+  "userId": 1,
+  "items": [
+    {
+      "productId": 1,
+      "quantity": 2,
+      "price": 109.95
+    },
+    {
+      "productId": 5,
+      "quantity": 1,
+      "price": 695.00
+    }
+  ]
+}
+```
+
+---
+
+## 📦 Technologies
+
+- Java 17
+- Spring Boot 3.4
+- Spring Data JPA
+- Spring Security (JWT)
+- PostgreSQL
+- Maven
+
+---
+
+## 🧩 Dependencies
+
+This service depends on:
+
+- `shopping-parent` for centralized config
+- `common-entities` for shared entities and DTOs
+
+---
+
+## 🗂 Folder Structure
+
+```
+src/main/java/com/shopping/order
+├── config             # Security and app config
+│   └── security       # JWT filter, utilities, chain
+├── controller         # REST controller for orders
+├── entity             # JPA entities (from common-entities)
+├── repository         # JPA Repositories
+├── service            # Order service interface & impl
+└── OrderServiceApplication.java
+```
+
+---
+
+## 🧪 Postman Testing
+
+Use the **Order Service API** Postman collection to test all endpoints.  
+Make sure to obtain a valid JWT token from the `shopping-auth` service.
+
+---
+
+## 📝 Note
+
+This service only implements **order management**.  
+Clients and Products are assumed to be managed by their respective microservices.

--- a/order-service/pom.xml
+++ b/order-service/pom.xml
@@ -1,0 +1,101 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.shopping</groupId>
+		<artifactId>shopping-parent</artifactId>
+		<version>1.0.0</version>
+		<relativePath>../shopping-parent</relativePath>
+	</parent>
+
+	<artifactId>order-service</artifactId>
+	<name>order-service</name>
+	<description>Microservice for managing orders in the shopping cart system</description>
+	<version>1.0.0</version>
+
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+
+	<dependencies>
+		<!-- Web -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<!-- JPA -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
+		<!-- PostgreSQL -->
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>42.7.2</version>
+			<scope>runtime</scope>
+		</dependency>
+
+		<!-- Security JWT -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+
+		<!-- Lombok -->
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Common DTOs or Entities -->
+		<dependency>
+			<groupId>com.shopping</groupId>
+			<artifactId>common-entities</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>3.2.2</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.10.1</version>
+				<configuration>
+					<parameters>true</parameters>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/order-service/run/start.sh
+++ b/order-service/run/start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+nohup java -Xmx1536m -Xms512m -Xss256k \
+-Dspring.profiles.active=production \
+-Duser.timezone=${KERO_SPRING_USER_TIME_ZONE} \
+-Dspring.datasource.hikari.connection-timeout=30000 \
+-jar ${KERO_HOME}/ems-service/ems-service.jar > /dev/null 2>&1 &

--- a/order-service/run/start_dev.sh
+++ b/order-service/run/start_dev.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+nohup java -Xmx512m -Xms128m -Xss256k \
+-Dspring.profiles.active=development \
+-Duser.timezone=${KERO_SPRING_USER_TIME_ZONE} \
+-Dspring.datasource.hikari.connection-timeout=30000 \
+-jar ${KERO_HOME}/ems-service/ems-service.jar > /dev/null 2>&1 &

--- a/order-service/src/main/java/com/shopping/order/OrderServiceApplication.java
+++ b/order-service/src/main/java/com/shopping/order/OrderServiceApplication.java
@@ -1,0 +1,24 @@
+package com.shopping.order;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@SpringBootApplication(scanBasePackages = {
+        "com.shopping.order",
+		"com.shopping.common.entity",
+		"com.shopping.exception"
+})
+@EntityScan(basePackages = {
+		"com.shopping.common.entity"
+})
+@EnableJpaRepositories(basePackages = {
+        "com.shopping.order.repository"
+})
+public class OrderServiceApplication {
+	public static void main(String[] args) {
+		SpringApplication.run(OrderServiceApplication.class, args);
+	}
+}
+

--- a/order-service/src/main/java/com/shopping/order/config/AppConfig.java
+++ b/order-service/src/main/java/com/shopping/order/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.shopping.order.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/order-service/src/main/java/com/shopping/order/config/security/JWTUtil.java
+++ b/order-service/src/main/java/com/shopping/order/config/security/JWTUtil.java
@@ -1,0 +1,59 @@
+package com.shopping.order.config.security;
+
+import com.shopping.common.entity.user.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JWTUtil {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    private Key getSigningKey() {
+        return Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    public String generateToken(User userDetails) {
+        return Jwts.builder()
+                .setSubject(userDetails.getUsername())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 10)) // 10 hours
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean validateToken(String token, User userDetails) {
+        return userDetails.getUsername().equals(extractUsername(token)) && !isTokenExpired(token);
+    }
+
+    public String extractUsername(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    public boolean isTokenExpired(String token) {
+        return getClaims(token).getExpiration().before(new Date());
+    }
+
+    public Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public String getCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication.getName();
+    }
+}

--- a/order-service/src/main/java/com/shopping/order/config/security/SecurityConfig.java
+++ b/order-service/src/main/java/com/shopping/order/config/security/SecurityConfig.java
@@ -1,0 +1,33 @@
+package com.shopping.order.config.security;
+
+import com.shopping.order.config.security.filter.JwtFilterRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+public class SecurityConfig {
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http, JwtFilterRequest jwtFilterRequest) throws Exception {
+		http.csrf(csrf -> csrf.disable())
+				.authorizeHttpRequests(auth -> auth
+						.requestMatchers("/actuator/health").permitAll()
+						.anyRequest().authenticated()
+				)
+				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+				.addFilterBefore(jwtFilterRequest, UsernamePasswordAuthenticationFilter.class);
+
+		return http.build();
+	}
+
+	@Bean
+	public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig) throws Exception {
+		return authConfig.getAuthenticationManager();
+	}
+}

--- a/order-service/src/main/java/com/shopping/order/config/security/filter/JwtFilterRequest.java
+++ b/order-service/src/main/java/com/shopping/order/config/security/filter/JwtFilterRequest.java
@@ -1,0 +1,62 @@
+package com.shopping.order.config.security.filter;
+
+import com.shopping.order.config.security.JWTUtil;
+import com.shopping.common.entity.user.User;
+import com.shopping.order.service.UserService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilterRequest extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+    private final UserService userService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String authorizationHeader = request.getHeader("Authorization");
+
+        try {
+            if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+                final String jwt = authorizationHeader.substring(7);
+                final String username = jwtUtil.extractUsername(jwt);
+
+                if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                    User userDetails = userService.getUserByUsername(username);
+
+                    if (jwtUtil.validateToken(jwt, userDetails)) {
+                        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                                userDetails, null, null);
+                        authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                        SecurityContextHolder.getContext().setAuthentication(authToken);
+                    }
+                }
+            }
+        } catch (io.jsonwebtoken.ExpiredJwtException e) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("Token expired");
+            return;
+        } catch (io.jsonwebtoken.JwtException | IllegalArgumentException e) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.getWriter().write("Invalid token");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/order-service/src/main/java/com/shopping/order/controller/OrderController.java
+++ b/order-service/src/main/java/com/shopping/order/controller/OrderController.java
@@ -1,0 +1,33 @@
+package com.shopping.order.controller;
+
+import com.shopping.common.dto.OrderRequestDto;
+import com.shopping.common.dto.OrderResponseDto;
+import com.shopping.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<OrderResponseDto> createOrder(@RequestBody OrderRequestDto request) {
+        return ResponseEntity.ok(orderService.createOrder(request));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<OrderResponseDto> getOrderById(@PathVariable Long id) {
+        return ResponseEntity.ok(orderService.getOrderById(id));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<OrderResponseDto>> getAllOrders() {
+        return ResponseEntity.ok(orderService.getAllOrders());
+    }
+}

--- a/order-service/src/main/java/com/shopping/order/repository/OrderRepository.java
+++ b/order-service/src/main/java/com/shopping/order/repository/OrderRepository.java
@@ -1,0 +1,17 @@
+package com.shopping.order.repository;
+
+import com.shopping.common.entity.order.Order;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    @EntityGraph(attributePaths = "orderDetails")
+    Optional<Order> findById(Long id);
+
+    @EntityGraph(attributePaths = "orderDetails")
+    List<Order> findAll();
+}

--- a/order-service/src/main/java/com/shopping/order/repository/UserRepository.java
+++ b/order-service/src/main/java/com/shopping/order/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.shopping.order.repository;
+
+import com.shopping.common.entity.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+
+}

--- a/order-service/src/main/java/com/shopping/order/service/OrderService.java
+++ b/order-service/src/main/java/com/shopping/order/service/OrderService.java
@@ -1,0 +1,12 @@
+package com.shopping.order.service;
+
+import com.shopping.common.dto.OrderResponseDto;
+import com.shopping.common.dto.OrderRequestDto;
+
+import java.util.List;
+
+public interface OrderService {
+    OrderResponseDto createOrder(OrderRequestDto request);
+    OrderResponseDto getOrderById(Long id);
+    List<OrderResponseDto> getAllOrders();
+}

--- a/order-service/src/main/java/com/shopping/order/service/UserService.java
+++ b/order-service/src/main/java/com/shopping/order/service/UserService.java
@@ -1,0 +1,9 @@
+package com.shopping.order.service;
+
+import com.shopping.common.entity.user.User;
+
+public interface UserService {
+
+    User getUserByUsername(String username);
+
+}

--- a/order-service/src/main/java/com/shopping/order/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/shopping/order/service/impl/OrderServiceImpl.java
@@ -1,0 +1,84 @@
+package com.shopping.order.service.impl;
+
+import com.shopping.common.dto.OrderRequestDto;
+import com.shopping.common.dto.OrderResponseDto;
+import com.shopping.common.dto.OrderItemDto;
+import com.shopping.common.entity.order.Order;
+import com.shopping.common.entity.order.OrderDetail;
+import com.shopping.order.repository.OrderRepository;
+import com.shopping.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class OrderServiceImpl implements OrderService {
+
+    private final OrderRepository orderRepository;
+
+    @Override
+    public OrderResponseDto createOrder(OrderRequestDto request) {
+        Order order = Order.builder()
+                .userId(request.getUserId())
+                .orderDate(LocalDateTime.now())
+                .total(request.getItems().stream().mapToDouble(i -> i.getPrice() * i.getQuantity()).sum())
+                .build();
+
+        order = orderRepository.save(order);
+
+        Order finalOrder = order;
+        List<OrderDetail> details = request.getItems().stream().map(item ->
+                OrderDetail.builder()
+                        .productId(item.getProductId())
+                        .quantity(item.getQuantity())
+                        .price(item.getPrice())
+                        .order(finalOrder)
+                        .build()
+        ).collect(Collectors.toList());
+
+        order.setOrderDetails(details);
+        order = orderRepository.save(order);
+
+        return OrderResponseDto.builder()
+                .id(order.getId())
+                .userId(order.getUserId())
+                .orderDate(order.getOrderDate())
+                .total(order.getTotal())
+                .items(request.getItems())
+                .build();
+    }
+
+    @Override
+    public OrderResponseDto getOrderById(Long id) {
+        return orderRepository.findById(id).map(order ->
+                OrderResponseDto.builder()
+                        .id(order.getId())
+                        .userId(order.getUserId())
+                        .orderDate(order.getOrderDate())
+                        .total(order.getTotal())
+                        .items(order.getOrderDetails().stream().map(detail ->
+                                new OrderItemDto(detail.getProductId(), detail.getQuantity(), detail.getPrice())
+                        ).collect(Collectors.toList()))
+                        .build()
+        ).orElseThrow(() -> new RuntimeException("Order not found"));
+    }
+
+    @Override
+    public List<OrderResponseDto> getAllOrders() {
+        return orderRepository.findAll().stream().map(order ->
+                OrderResponseDto.builder()
+                        .id(order.getId())
+                        .userId(order.getUserId())
+                        .orderDate(order.getOrderDate())
+                        .total(order.getTotal())
+                        .items(order.getOrderDetails().stream().map(detail ->
+                                new OrderItemDto(detail.getProductId(), detail.getQuantity(), detail.getPrice())
+                        ).collect(Collectors.toList()))
+                        .build()
+        ).collect(Collectors.toList());
+    }
+}

--- a/order-service/src/main/java/com/shopping/order/service/impl/UserServiceImpl.java
+++ b/order-service/src/main/java/com/shopping/order/service/impl/UserServiceImpl.java
@@ -1,0 +1,26 @@
+package com.shopping.order.service.impl;
+
+import com.shopping.order.config.security.JWTUtil;
+import com.shopping.order.repository.UserRepository;
+import com.shopping.order.service.UserService;
+import com.shopping.common.entity.user.User;
+import com.shopping.exception.impl.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final JWTUtil jwtUtil;
+
+
+    @Override
+    public User getUserByUsername(String username) {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new NotFoundException("User not found"));
+    }
+
+}

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -1,0 +1,37 @@
+server:
+  port: 8083
+  servlet:
+    context-path: /order-service
+
+spring:
+  application:
+    name: order-service
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://localhost:5432/shopping-cart-db
+    username: postgres
+    password: root
+    hikari:
+      connection-timeout: 10000
+      idle-timeout: 50000
+      minimum-idle: 1
+      maximum-pool-size: 10
+      connection-test-query: SELECT 1
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    database: postgresql
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        default_schema: public
+
+jwt:
+  secret: Z3nU52@93xDklq902hAs78bLcNjsL29cHSsA9kPmsJq9kdPoaVq
+
+logging:
+  level:
+    root: INFO
+    org.springframework.web: DEBUG

--- a/product-service/.gitignore
+++ b/product-service/.gitignore
@@ -1,0 +1,34 @@
+HELP.md
+target/
+!**/src/main/**/target/
+!**/src/test/**/target/
+.mvn
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+bin/

--- a/product-service/README.md
+++ b/product-service/README.md
@@ -1,0 +1,71 @@
+# 🛍️ Product Service
+
+This microservice acts as a **proxy** to the public [FakeStoreAPI](https://fakestoreapi.com), allowing secure access to product information for the shopping cart system.
+
+---
+
+## 🔐 JWT Authentication
+
+All endpoints (except `/actuator/health`) require a valid **JWT token**.
+
+- Add the token in Postman under **Authorization → Bearer Token**, or
+- Include in header: `Authorization: Bearer <your_token>`
+
+---
+
+## 🚀 Endpoints
+
+| Method | Endpoint                          | Description                              |
+|--------|-----------------------------------|------------------------------------------|
+| GET    | `/v1/products`                    | Get all products                         |
+| GET    | `/v1/products/{id}`               | Get a product by ID                      |
+| GET    | `/v1/products/category/{name}`    | Get products by category                 |
+| POST   | `/v1/products`                    | Add a new product (fake)                 |
+| PUT    | `/v1/products/{id}`               | Update an existing product (fake)        |
+| DELETE | `/v1/products/{id}`               | Delete a product (fake)                  |
+
+---
+
+## ⚙️ Technologies
+
+- Java 17
+- Spring Boot 3.4
+- Spring Security (JWT)
+- RestTemplate
+- Maven
+
+---
+
+## 🧩 Dependencies
+
+This service depends on:
+
+- `shopping-parent` for common configurations
+- `common-entities` for shared DTOs/entities
+
+---
+
+## 📦 Folder Structure
+
+```
+src/main/java/com/shopping/product
+├── config             # App and Security config
+│   └── security       # JWT filter, util, security chain
+├── controller         # REST controller for products
+├── service            # Product service interface and impl
+└── ProductServiceApplication.java
+```
+
+---
+
+## 🧪 Postman Testing
+
+You can test endpoints by importing the **Product Service API** collection and setting the `Authorization` header using a token from `shopping-auth`.
+
+---
+
+## 🌐 External API Reference
+
+All calls are delegated to:
+
+[https://fakestoreapi.com](https://fakestoreapi.com)

--- a/product-service/pom.xml
+++ b/product-service/pom.xml
@@ -1,0 +1,104 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.shopping</groupId>
+		<artifactId>shopping-parent</artifactId>
+		<version>1.0.0</version>
+		<relativePath>../shopping-parent</relativePath>
+	</parent>
+
+	<artifactId>product-service</artifactId>
+	<name>product-service</name>
+	<description>Proxy microservice for fetching product data from fakestoreapi.com</description>
+	<version>1.0.0</version>
+
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+
+	<dependencies>
+		<!-- Spring Boot Web -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<!-- Spring Security -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
+		<!-- JPA for user authentication check -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
+		<!-- PostgreSQL driver -->
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>42.7.2</version>
+			<scope>runtime</scope>
+		</dependency>
+
+		<!-- JWT -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+
+		<!-- Lombok -->
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Shared Entities (User, Role, etc.) -->
+		<dependency>
+			<groupId>com.shopping</groupId>
+			<artifactId>common-entities</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>3.2.2</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.10.1</version>
+				<configuration>
+					<parameters>true</parameters>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/product-service/run/start.sh
+++ b/product-service/run/start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+nohup java -Xmx1536m -Xms512m -Xss256k \
+-Dspring.profiles.active=production \
+-Duser.timezone=${KERO_SPRING_USER_TIME_ZONE} \
+-Dspring.datasource.hikari.connection-timeout=30000 \
+-jar ${KERO_HOME}/ems-service/ems-service.jar > /dev/null 2>&1 &

--- a/product-service/run/start_dev.sh
+++ b/product-service/run/start_dev.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+nohup java -Xmx512m -Xms128m -Xss256k \
+-Dspring.profiles.active=development \
+-Duser.timezone=${KERO_SPRING_USER_TIME_ZONE} \
+-Dspring.datasource.hikari.connection-timeout=30000 \
+-jar ${KERO_HOME}/ems-service/ems-service.jar > /dev/null 2>&1 &

--- a/product-service/src/main/java/com/shopping/product/ProductServiceApplication.java
+++ b/product-service/src/main/java/com/shopping/product/ProductServiceApplication.java
@@ -1,0 +1,23 @@
+package com.shopping.product;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@SpringBootApplication(scanBasePackages = {
+        "com.shopping.product",
+		"com.shopping.common.entity",
+		"com.shopping.exception"
+})
+@EntityScan(basePackages = {
+		"com.shopping.common.entity"
+})
+@EnableJpaRepositories(basePackages = {
+        "com.shopping.product.repository"
+})
+public class ProductServiceApplication {
+	public static void main(String[] args) {
+		SpringApplication.run(ProductServiceApplication.class, args);
+	}
+}

--- a/product-service/src/main/java/com/shopping/product/config/AppConfig.java
+++ b/product-service/src/main/java/com/shopping/product/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.shopping.product.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/product-service/src/main/java/com/shopping/product/config/security/JWTUtil.java
+++ b/product-service/src/main/java/com/shopping/product/config/security/JWTUtil.java
@@ -1,0 +1,59 @@
+package com.shopping.product.config.security;
+
+import com.shopping.common.entity.user.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JWTUtil {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    private Key getSigningKey() {
+        return Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    public String generateToken(User userDetails) {
+        return Jwts.builder()
+                .setSubject(userDetails.getUsername())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 10)) // 10 hours
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean validateToken(String token, User userDetails) {
+        return userDetails.getUsername().equals(extractUsername(token)) && !isTokenExpired(token);
+    }
+
+    public String extractUsername(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    public boolean isTokenExpired(String token) {
+        return getClaims(token).getExpiration().before(new Date());
+    }
+
+    public Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public String getCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication.getName();
+    }
+}

--- a/product-service/src/main/java/com/shopping/product/config/security/SecurityConfig.java
+++ b/product-service/src/main/java/com/shopping/product/config/security/SecurityConfig.java
@@ -1,0 +1,33 @@
+package com.shopping.product.config.security;
+
+import com.shopping.product.config.security.filter.JwtFilterRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+public class SecurityConfig {
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http, JwtFilterRequest jwtFilterRequest) throws Exception {
+		http.csrf(csrf -> csrf.disable())
+				.authorizeHttpRequests(auth -> auth
+						.requestMatchers("/actuator/health").permitAll()
+						.anyRequest().authenticated()
+				)
+				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+				.addFilterBefore(jwtFilterRequest, UsernamePasswordAuthenticationFilter.class);
+
+		return http.build();
+	}
+
+	@Bean
+	public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig) throws Exception {
+		return authConfig.getAuthenticationManager();
+	}
+}

--- a/product-service/src/main/java/com/shopping/product/config/security/filter/JwtFilterRequest.java
+++ b/product-service/src/main/java/com/shopping/product/config/security/filter/JwtFilterRequest.java
@@ -1,0 +1,62 @@
+package com.shopping.product.config.security.filter;
+
+import com.shopping.product.config.security.JWTUtil;
+import com.shopping.common.entity.user.User;
+import com.shopping.product.service.UserService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilterRequest extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+    private final UserService userService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String authorizationHeader = request.getHeader("Authorization");
+
+        try {
+            if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+                final String jwt = authorizationHeader.substring(7);
+                final String username = jwtUtil.extractUsername(jwt);
+
+                if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                    User userDetails = userService.getUserByUsername(username);
+
+                    if (jwtUtil.validateToken(jwt, userDetails)) {
+                        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                                userDetails, null, null);
+                        authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                        SecurityContextHolder.getContext().setAuthentication(authToken);
+                    }
+                }
+            }
+        } catch (io.jsonwebtoken.ExpiredJwtException e) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("Token expired");
+            return;
+        } catch (io.jsonwebtoken.JwtException | IllegalArgumentException e) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.getWriter().write("Invalid token");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/product-service/src/main/java/com/shopping/product/controller/ProductController.java
+++ b/product-service/src/main/java/com/shopping/product/controller/ProductController.java
@@ -1,0 +1,46 @@
+package com.shopping.product.controller;
+
+import com.shopping.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/v1/products")
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductService productService;
+
+    @GetMapping
+    public ResponseEntity<?> getAllProducts() {
+        return ResponseEntity.ok(productService.getAllProducts());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getProductById(@PathVariable Long id) {
+        return ResponseEntity.ok(productService.getProductById(id));
+    }
+
+    @GetMapping("/category/{name}")
+    public ResponseEntity<?> getProductsByCategory(@PathVariable String name) {
+        return ResponseEntity.ok(productService.getProductsByCategory(name));
+    }
+
+    @PostMapping
+    public ResponseEntity<?> createProduct(@RequestBody Map<String, Object> product) {
+        return ResponseEntity.ok(productService.createProduct(product));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> updateProduct(@PathVariable Long id, @RequestBody Map<String, Object> product) {
+        return ResponseEntity.ok(productService.updateProduct(id, product));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteProduct(@PathVariable Long id) {
+        return ResponseEntity.ok(productService.deleteProduct(id));
+    }
+}

--- a/product-service/src/main/java/com/shopping/product/repository/UserRepository.java
+++ b/product-service/src/main/java/com/shopping/product/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.shopping.product.repository;
+
+import com.shopping.common.entity.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+
+}

--- a/product-service/src/main/java/com/shopping/product/service/ProductService.java
+++ b/product-service/src/main/java/com/shopping/product/service/ProductService.java
@@ -1,0 +1,13 @@
+package com.shopping.product.service;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ProductService {
+    List<Map<String, Object>> getAllProducts();
+    Map<String, Object> getProductById(Long id);
+    List<Map<String, Object>> getProductsByCategory(String category);
+    Map<String, Object> createProduct(Map<String, Object> product);
+    Map<String, Object> updateProduct(Long id, Map<String, Object> product);
+    Map<String, Object> deleteProduct(Long id);
+}

--- a/product-service/src/main/java/com/shopping/product/service/UserService.java
+++ b/product-service/src/main/java/com/shopping/product/service/UserService.java
@@ -1,0 +1,9 @@
+package com.shopping.product.service;
+
+import com.shopping.common.entity.user.User;
+
+public interface UserService {
+
+    User getUserByUsername(String username);
+
+}

--- a/product-service/src/main/java/com/shopping/product/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/com/shopping/product/service/impl/ProductServiceImpl.java
@@ -1,0 +1,50 @@
+package com.shopping.product.service.impl;
+
+import com.shopping.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ProductServiceImpl implements ProductService {
+
+    private final String BASE_URL = "https://fakestoreapi.com/products";
+    private final RestTemplate restTemplate;
+
+    @Override
+    public List<Map<String, Object>> getAllProducts() {
+        return Arrays.asList(restTemplate.getForObject(BASE_URL, Map[].class));
+    }
+
+    @Override
+    public Map<String, Object> getProductById(Long id) {
+        return restTemplate.getForObject(BASE_URL + "/" + id, Map.class);
+    }
+
+    @Override
+    public List<Map<String, Object>> getProductsByCategory(String category) {
+        return Arrays.asList(restTemplate.getForObject(BASE_URL + "/category/" + category, Map[].class));
+    }
+
+    @Override
+    public Map<String, Object> createProduct(Map<String, Object> product) {
+        return restTemplate.postForObject(BASE_URL, product, Map.class);
+    }
+
+    @Override
+    public Map<String, Object> updateProduct(Long id, Map<String, Object> product) {
+        restTemplate.put(BASE_URL + "/" + id, product);
+        return product;
+    }
+
+    @Override
+    public Map<String, Object> deleteProduct(Long id) {
+        restTemplate.delete(BASE_URL + "/" + id);
+        return Map.of("message", "Product deleted successfully (fake)");
+    }
+}

--- a/product-service/src/main/java/com/shopping/product/service/impl/UserServiceImpl.java
+++ b/product-service/src/main/java/com/shopping/product/service/impl/UserServiceImpl.java
@@ -1,0 +1,26 @@
+package com.shopping.product.service.impl;
+
+import com.shopping.product.config.security.JWTUtil;
+import com.shopping.product.repository.UserRepository;
+import com.shopping.product.service.UserService;
+import com.shopping.common.entity.user.User;
+import com.shopping.exception.impl.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final JWTUtil jwtUtil;
+
+
+    @Override
+    public User getUserByUsername(String username) {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new NotFoundException("User not found"));
+    }
+
+}

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -1,0 +1,37 @@
+server:
+  port: 8082
+  servlet:
+    context-path: /product-service
+
+spring:
+  application:
+    name: product-service
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://localhost:5432/shopping-cart-db
+    username: postgres
+    password: root
+    hikari:
+      connection-timeout: 10000
+      idle-timeout: 50000
+      minimum-idle: 1
+      maximum-pool-size: 10
+      connection-test-query: SELECT 1
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: true
+    database: postgresql
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        default_schema: public
+
+jwt:
+  secret: Z3nU52@93xDklq902hAs78bLcNjsL29cHSsA9kPmsJq9kdPoaVq
+
+logging:
+  level:
+    root: INFO
+    org.springframework.web: DEBUG


### PR DESCRIPTION
- Implemented Order and OrderDetail entities to persist order data.
- Created DTOs for request/response handling: OrderRequestDto, OrderResponseDto, OrderItemDto.
- Developed OrderController with the following endpoints:
    • POST /v1/orders → create order
    • GET /v1/orders/{id} → retrieve single order
    • GET /v1/orders → list all orders
- Integrated OrderService with save and fetch logic using JPA.
- Applied @EntityGraph to solve LazyInitializationException on order details.
- Configured JWT authentication for all endpoints using custom JwtFilterRequest.
- Fully integrated with common-entities module.
- Added README.md with API documentation and setup details.
- Added Postman collection: Order Service API.postman_collection.json for testing.
