### PR TITLE
Add payment-service: simulate payment processing and status retrieval

### DIFF
--- a/common-entities/src/main/java/com/shopping/common/dto/PaymentRequestDto.java
+++ b/common-entities/src/main/java/com/shopping/common/dto/PaymentRequestDto.java
@@ -1,0 +1,14 @@
+package com.shopping.common.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentRequestDto {
+    private Long orderId;
+    private Double amount;
+    private String paymentMethod;
+}

--- a/common-entities/src/main/java/com/shopping/common/dto/PaymentResponseDto.java
+++ b/common-entities/src/main/java/com/shopping/common/dto/PaymentResponseDto.java
@@ -1,0 +1,17 @@
+package com.shopping.common.dto;
+
+import com.shopping.common.enums.PaymentStatus;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentResponseDto {
+    private Long paymentId;
+    private PaymentStatus status;
+    private LocalDateTime timestamp;
+}

--- a/common-entities/src/main/java/com/shopping/common/entity/payment/Payment.java
+++ b/common-entities/src/main/java/com/shopping/common/entity/payment/Payment.java
@@ -1,0 +1,32 @@
+package com.shopping.common.entity.payment;
+
+import com.shopping.common.enums.PaymentStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "payments")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Payment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long orderId;
+
+    private Double amount;
+
+    private String paymentMethod;
+
+    @Enumerated(EnumType.STRING)
+    private PaymentStatus status;
+
+    private LocalDateTime timestamp;
+}

--- a/common-entities/src/main/java/com/shopping/common/enums/PaymentStatus.java
+++ b/common-entities/src/main/java/com/shopping/common/enums/PaymentStatus.java
@@ -1,0 +1,7 @@
+package com.shopping.common.enums;
+
+public enum PaymentStatus {
+    PENDING,
+    COMPLETED,
+    FAILED
+}

--- a/payment-service/.gitignore
+++ b/payment-service/.gitignore
@@ -1,0 +1,34 @@
+HELP.md
+target/
+!**/src/main/**/target/
+!**/src/test/**/target/
+.mvn
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+bin/

--- a/payment-service/README.md
+++ b/payment-service/README.md
@@ -1,0 +1,86 @@
+# 💳 Payment Service
+
+This microservice simulates the **payment process** for the shopping cart system. It handles payment requests and returns a simulated payment status.
+
+---
+
+## 🔐 JWT Authentication
+
+All endpoints (except `/actuator/health`) are **protected** with JWT.
+
+- Add your token in Postman under **Authorization → Bearer Token**, or  
+- Include it in the headers as:  
+  `Authorization: Bearer <your_token>`
+
+---
+
+## 🚀 Endpoints
+
+| Method | Endpoint                 | Description                        |
+|--------|--------------------------|------------------------------------|
+| POST   | `/v1/payments/process`   | Simulate a payment process         |
+| GET    | `/v1/payments/status/{orderId}` | Get simulated payment status by order ID |
+
+---
+
+## 🧾 Sample Request - Process Payment
+
+```json
+POST /v1/payments/process
+Authorization: Bearer <your_token>
+Content-Type: application/json
+
+{
+  "orderId": 101,
+  "amount": 250.00,
+  "paymentMethod": "CREDIT_CARD"
+}
+```
+
+---
+
+## 📦 Technologies
+
+- Java 17
+- Spring Boot 3.4
+- Spring Security (JWT)
+- Maven
+
+---
+
+## 🧩 Dependencies
+
+This service depends on:
+
+- `shopping-parent` for centralized config
+- `common-entities` for shared DTOs and Enums
+
+---
+
+## 🗂 Folder Structure
+
+```
+src/main/java/com/shopping/payment
+├── config             # Security and app config
+│   └── security       # JWT filter, utilities, chain
+├── controller         # REST controller for payments
+├── dto                # PaymentRequestDto and PaymentResponseDto
+├── service            # Payment service interface and impl
+├── entity             # Payment entity (persisted in DB)
+├── enums              # PaymentStatus enum
+└── PaymentServiceApplication.java
+```
+
+---
+
+## 🧪 Postman Testing
+
+Use the **Payment Service API** Postman collection to test all endpoints.  
+Make sure to obtain a valid JWT token from the `shopping-auth` service.
+
+---
+
+## 📝 Note
+
+This service simulates payment processing.  
+No real transactions are performed.

--- a/payment-service/pom.xml
+++ b/payment-service/pom.xml
@@ -1,0 +1,102 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.shopping</groupId>
+        <artifactId>shopping-parent</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../shopping-parent</relativePath>
+    </parent>
+
+    <artifactId>payment-service</artifactId>
+    <name>payment-service</name>
+    <description>Microservice to simulate payment processing for orders</description>
+    <version>1.0.0</version>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <!-- Web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- JPA -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <!-- PostgreSQL -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.2</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Security JWT -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Common DTOs or Entities -->
+        <dependency>
+            <groupId>com.shopping</groupId>
+            <artifactId>common-entities</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>3.2.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <parameters>true</parameters>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/payment-service/run/start.sh
+++ b/payment-service/run/start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+nohup java -Xmx1536m -Xms512m -Xss256k \
+-Dspring.profiles.active=production \
+-Duser.timezone=${KERO_SPRING_USER_TIME_ZONE} \
+-Dspring.datasource.hikari.connection-timeout=30000 \
+-jar ${KERO_HOME}/ems-service/ems-service.jar > /dev/null 2>&1 &

--- a/payment-service/run/start_dev.sh
+++ b/payment-service/run/start_dev.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+nohup java -Xmx512m -Xms128m -Xss256k \
+-Dspring.profiles.active=development \
+-Duser.timezone=${KERO_SPRING_USER_TIME_ZONE} \
+-Dspring.datasource.hikari.connection-timeout=30000 \
+-jar ${KERO_HOME}/ems-service/ems-service.jar > /dev/null 2>&1 &

--- a/payment-service/src/main/java/com/shopping/payment/PaymentServiceApplication.java
+++ b/payment-service/src/main/java/com/shopping/payment/PaymentServiceApplication.java
@@ -1,0 +1,24 @@
+package com.shopping.payment;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@SpringBootApplication(scanBasePackages = {
+        "com.shopping.payment",
+		"com.shopping.common.entity",
+		"com.shopping.exception"
+})
+@EntityScan(basePackages = {
+		"com.shopping.common.entity"
+})
+@EnableJpaRepositories(basePackages = {
+        "com.shopping.payment.repository"
+})
+public class PaymentServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(PaymentServiceApplication.class, args);
+    }
+}
+

--- a/payment-service/src/main/java/com/shopping/payment/config/AppConfig.java
+++ b/payment-service/src/main/java/com/shopping/payment/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.shopping.payment.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/payment-service/src/main/java/com/shopping/payment/config/security/JWTUtil.java
+++ b/payment-service/src/main/java/com/shopping/payment/config/security/JWTUtil.java
@@ -1,0 +1,59 @@
+package com.shopping.payment.config.security;
+
+import com.shopping.common.entity.user.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JWTUtil {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    private Key getSigningKey() {
+        return Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    public String generateToken(User userDetails) {
+        return Jwts.builder()
+                .setSubject(userDetails.getUsername())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 10)) // 10 hours
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean validateToken(String token, User userDetails) {
+        return userDetails.getUsername().equals(extractUsername(token)) && !isTokenExpired(token);
+    }
+
+    public String extractUsername(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    public boolean isTokenExpired(String token) {
+        return getClaims(token).getExpiration().before(new Date());
+    }
+
+    public Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public String getCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication.getName();
+    }
+}

--- a/payment-service/src/main/java/com/shopping/payment/config/security/SecurityConfig.java
+++ b/payment-service/src/main/java/com/shopping/payment/config/security/SecurityConfig.java
@@ -1,0 +1,33 @@
+package com.shopping.payment.config.security;
+
+import com.shopping.payment.config.security.filter.JwtFilterRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+public class SecurityConfig {
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http, JwtFilterRequest jwtFilterRequest) throws Exception {
+		http.csrf(csrf -> csrf.disable())
+				.authorizeHttpRequests(auth -> auth
+						.requestMatchers("/actuator/health").permitAll()
+						.anyRequest().authenticated()
+				)
+				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+				.addFilterBefore(jwtFilterRequest, UsernamePasswordAuthenticationFilter.class);
+
+		return http.build();
+	}
+
+	@Bean
+	public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig) throws Exception {
+		return authConfig.getAuthenticationManager();
+	}
+}

--- a/payment-service/src/main/java/com/shopping/payment/config/security/filter/JwtFilterRequest.java
+++ b/payment-service/src/main/java/com/shopping/payment/config/security/filter/JwtFilterRequest.java
@@ -1,0 +1,62 @@
+package com.shopping.payment.config.security.filter;
+
+import com.shopping.payment.config.security.JWTUtil;
+import com.shopping.common.entity.user.User;
+import com.shopping.payment.service.UserService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilterRequest extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+    private final UserService userService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String authorizationHeader = request.getHeader("Authorization");
+
+        try {
+            if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+                final String jwt = authorizationHeader.substring(7);
+                final String username = jwtUtil.extractUsername(jwt);
+
+                if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                    User userDetails = userService.getUserByUsername(username);
+
+                    if (jwtUtil.validateToken(jwt, userDetails)) {
+                        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                                userDetails, null, null);
+                        authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                        SecurityContextHolder.getContext().setAuthentication(authToken);
+                    }
+                }
+            }
+        } catch (io.jsonwebtoken.ExpiredJwtException e) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("Token expired");
+            return;
+        } catch (io.jsonwebtoken.JwtException | IllegalArgumentException e) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.getWriter().write("Invalid token");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/payment-service/src/main/java/com/shopping/payment/controller/PaymentController.java
+++ b/payment-service/src/main/java/com/shopping/payment/controller/PaymentController.java
@@ -1,0 +1,27 @@
+package com.shopping.payment.controller;
+
+import com.shopping.common.dto.PaymentRequestDto;
+import com.shopping.common.dto.PaymentResponseDto;
+import com.shopping.payment.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v1/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @PostMapping("/process")
+    public ResponseEntity<PaymentResponseDto> processPayment(@RequestBody PaymentRequestDto request) {
+        return ResponseEntity.ok(paymentService.processPayment(request));
+    }
+
+    @GetMapping("/status/{orderId}")
+    public ResponseEntity<PaymentResponseDto> getStatus(@PathVariable Long orderId) {
+        return ResponseEntity.ok(paymentService.getPaymentStatus(orderId));
+    }
+
+}

--- a/payment-service/src/main/java/com/shopping/payment/repository/PaymentRepository.java
+++ b/payment-service/src/main/java/com/shopping/payment/repository/PaymentRepository.java
@@ -1,0 +1,10 @@
+package com.shopping.payment.repository;
+
+import com.shopping.common.entity.payment.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    Optional<Payment> findByOrderId(Long orderId);
+}

--- a/payment-service/src/main/java/com/shopping/payment/repository/UserRepository.java
+++ b/payment-service/src/main/java/com/shopping/payment/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.shopping.payment.repository;
+
+import com.shopping.common.entity.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+
+}

--- a/payment-service/src/main/java/com/shopping/payment/service/PaymentService.java
+++ b/payment-service/src/main/java/com/shopping/payment/service/PaymentService.java
@@ -1,0 +1,9 @@
+package com.shopping.payment.service;
+
+import com.shopping.common.dto.PaymentRequestDto;
+import com.shopping.common.dto.PaymentResponseDto;
+
+public interface PaymentService {
+    PaymentResponseDto processPayment(PaymentRequestDto request);
+    PaymentResponseDto getPaymentStatus(Long orderId);
+}

--- a/payment-service/src/main/java/com/shopping/payment/service/UserService.java
+++ b/payment-service/src/main/java/com/shopping/payment/service/UserService.java
@@ -1,0 +1,9 @@
+package com.shopping.payment.service;
+
+import com.shopping.common.entity.user.User;
+
+public interface UserService {
+
+    User getUserByUsername(String username);
+
+}

--- a/payment-service/src/main/java/com/shopping/payment/service/impl/PaymentServiceImpl.java
+++ b/payment-service/src/main/java/com/shopping/payment/service/impl/PaymentServiceImpl.java
@@ -1,0 +1,42 @@
+package com.shopping.payment.service.impl;
+
+
+import com.shopping.common.dto.PaymentRequestDto;
+import com.shopping.common.dto.PaymentResponseDto;
+import com.shopping.common.enums.PaymentStatus;
+import com.shopping.payment.service.PaymentService;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Service
+public class PaymentServiceImpl implements PaymentService {
+
+    private final Map<Long, PaymentResponseDto> paymentStore = new ConcurrentHashMap<>();
+    private final AtomicLong idGenerator = new AtomicLong(1);
+
+    @Override
+    public PaymentResponseDto processPayment(PaymentRequestDto request) {
+        PaymentResponseDto response = PaymentResponseDto.builder()
+                .paymentId(idGenerator.getAndIncrement())
+                .status(PaymentStatus.COMPLETED)
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        paymentStore.put(request.getOrderId(), response);
+        return response;
+    }
+
+    @Override
+    public PaymentResponseDto getPaymentStatus(Long orderId) {
+        return paymentStore.getOrDefault(orderId,
+                PaymentResponseDto.builder()
+                        .paymentId(-1L)
+                        .status(PaymentStatus.PENDING)
+                        .timestamp(LocalDateTime.now())
+                        .build());
+    }
+}

--- a/payment-service/src/main/java/com/shopping/payment/service/impl/UserServiceImpl.java
+++ b/payment-service/src/main/java/com/shopping/payment/service/impl/UserServiceImpl.java
@@ -1,0 +1,26 @@
+package com.shopping.payment.service.impl;
+
+import com.shopping.payment.config.security.JWTUtil;
+import com.shopping.payment.repository.UserRepository;
+import com.shopping.payment.service.UserService;
+import com.shopping.common.entity.user.User;
+import com.shopping.exception.impl.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final JWTUtil jwtUtil;
+
+
+    @Override
+    public User getUserByUsername(String username) {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new NotFoundException("User not found"));
+    }
+
+}

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -1,0 +1,37 @@
+server:
+  port: 8084
+  servlet:
+    context-path: /payment-service
+
+spring:
+  application:
+    name: payment-service
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://localhost:5432/shopping-cart-db
+    username: postgres
+    password: root
+    hikari:
+      connection-timeout: 10000
+      idle-timeout: 50000
+      minimum-idle: 1
+      maximum-pool-size: 10
+      connection-test-query: SELECT 1
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    database: postgresql
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        default_schema: public
+
+jwt:
+  secret: Z3nU52@93xDklq902hAs78bLcNjsL29cHSsA9kPmsJq9kdPoaVq
+
+logging:
+  level:
+    root: INFO
+    org.springframework.web: DEBUG

--- a/shopping-parent/pom.xml
+++ b/shopping-parent/pom.xml
@@ -13,7 +13,7 @@
 
 	<properties>
 		<java.version>17</java.version>
-		<spring.boot.version>3.4.3</spring.boot.version>
+		<spring.boot.version>3.4.4</spring.boot.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>


### PR DESCRIPTION
Add payment-service: simulate payment processing and status retrieval

- Created PaymentController with POST /v1/payments/process and GET /v1/payments/status/{orderId}
- Implemented PaymentService and PaymentServiceImpl with in-memory simulation
- Added DTOs: PaymentRequestDto and PaymentResponseDto
- Defined PaymentStatus enum (PENDING, COMPLETED, FAILED)
- Created Payment entity and repository to persist simulated payments
- Added JWT authentication to secure endpoints
- Integrated payment-service to use common-entities
- Added initial Postman collection for endpoint testing
- Updated application.yml and pom.xml accordingly